### PR TITLE
SIP-0003: Replace permission requirement with link requirement

### DIFF
--- a/sips/sip-0003.txt
+++ b/sips/sip-0003.txt
@@ -27,5 +27,5 @@ To contribute to a Stackjoin:
 
 How to publish a Stackjoin:
 	1a) (pooled) Collect all contributions.
-    1b) (unpooled) Request approval from the orphaned stack's publisher. A tweet by the publisher indicating anyone can Stackjoin it or authorization via DM or other messaging platforms qualify.
+    1b) (unpooled) Link to all original posts. This is required to prevent double spends.
 	2) Publish a reply to the tip of the current stackchain (the original Stackchain or a NEWSTACK) with all pictures of purchases.


### PR DESCRIPTION
This amendment replaces the permission requirement with a link requirement to make it easier to Stackjoin when one or more participants are unavailable.

Please *do not* merge without reviews.